### PR TITLE
AB#8129 Set IncludeServerUrlInMediaUrls to false in local/dev environment

### DIFF
--- a/docker/build/cm/Data/App_Config/Include/Sitecore.Media.Dev.config
+++ b/docker/build/cm/Data/App_Config/Include/Sitecore.Media.Dev.config
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/">
+  <sitecore>
+    <!--
+      Media URLs resolving
+      Tells Sitecore to not include the Sitecore server URL as part of the media requests, so that they are instead routed through Next.js rewrites (see next.config.js).
+      This eliminates exposing the Sitecore server publicly.
+    -->
+    <layoutService>
+      <configurations>
+        <config name="sxa-jss">
+          <rendering>
+            <renderingContentsResolver>
+              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
+            </renderingContentsResolver>
+          </rendering>
+        </config>
+      </configurations>
+    </layoutService>
+  </sitecore>
+</configuration>


### PR DESCRIPTION
Added as a separate file to make sure it is only deployed on local, not in XM Cloud.