### PR TITLE
Update GitVersion to 5.11.1

### DIFF
--- a/docker/version.yml
+++ b/docker/version.yml
@@ -2,7 +2,7 @@ steps:
 - task: gitversion/setup@0
   displayName: 'Install GitVersion'
   inputs:
-    versionSpec: '5.7.0'
+    versionSpec: '5.11.1'
 - task: gitversion/execute@0
   displayName: 'Execute GitVersion'
   inputs:


### PR DESCRIPTION
Azure DevOps build image got updated and no longer support older .NET.